### PR TITLE
Added entries for Storage Service Documentation

### DIFF
--- a/_data/showcase.json
+++ b/_data/showcase.json
@@ -36,7 +36,7 @@
                     "url": "https://pages.github.hpe.com/caf/storage-services"
                 },
                 "repository_button": {
-                    "text": "Elements on GitHub",
+                    "text": "Storage Services on GitHub",
                     "url": "https://github.hpe.com/caf/storage-services"
                 }
             }

--- a/_data/showcase.json
+++ b/_data/showcase.json
@@ -39,7 +39,6 @@
                     "text": "Elements on GitHub",
                     "url": "https://github.hpe.com/caf/storage-services"
                 }
-		 
             }
         },
         {

--- a/_data/showcase.json
+++ b/_data/showcase.json
@@ -30,7 +30,16 @@
             "en-us": {
                 "title": "Storage Service",                
                 "content": "showcase/en-us/services/storage.md",
-                "color": "bronze" 
+                "color": "bronze",
+		"site_button": {
+                    "text": "Storage Service Site",
+                    "url": "https://pages.github.hpe.com/caf/storage-services"
+                },
+                "repository_button": {
+                    "text": "Elements on GitHub",
+                    "url": "https://github.hpe.com/caf/storage-services"
+                }
+		 
             }
         },
         {


### PR DESCRIPTION
I have added entries for storage documentation that points to the storage services repository where all documentation has been created according to the mandate