### PR TITLE
CAF-2346: Updated auditing documentation links to point to new aggregator project.

### DIFF
--- a/_data/showcase.json
+++ b/_data/showcase.json
@@ -89,11 +89,11 @@
                 "image": "assets/img/audit.png",
                 "site_button": {
                     "text": "Auditing Site",
-                    "url": "https://pages.github.hpe.com/caf/caf-audit"
+                    "url": "https://pages.github.hpe.com/caf/audit-service"
                 },
                 "repository_button": {
                     "text": "Auditing on GitHub",
-                    "url": "https://github.hpe.com/caf/caf-audit"
+                    "url": "https://github.hpe.com/caf/audit-service"
                 }
             }
         },


### PR DESCRIPTION
Fix to help address loss of auditing documentation. A new 'gh-pages' branch for audit-service has also been generated and published as required.